### PR TITLE
Reduce Noise and Add Support for New/More Services

### DIFF
--- a/aws_list_all/client.py
+++ b/aws_list_all/client.py
@@ -3,17 +3,21 @@ import boto3
 _CLIENTS = {}
 
 
-def get_regions_for_service(service):
-    """Given a service name, return a list of region names where this service can have resources"""
+def get_regions_for_service(service, regions=()):
+    """Given a service name, return a list of region names where this service can have resources,
+    restricted by a possible set of regions."""
     if service == "s3":
         return ['us-east-1']  # s3 ListBuckets is a global request, so no region required.
-    return boto3.Session().get_available_regions(service) or [None]
+    service_regions = boto3.Session().get_available_regions(service)
+    if regions:
+        # If regions were passed, return the intersecion.
+        return [r for r in regions if r in service_regions]
+    else:
+        return service_regions
 
 
 def get_client(service, region=None):
     """Return (cached) boto3 clients for this service and this region"""
-    if not region:
-        region = get_regions_for_service(service)[0]
     if (service, region) not in _CLIENTS:
         _CLIENTS[(service, region)] = boto3.Session(region_name=region).client(service)
     return _CLIENTS[(service, region)]

--- a/aws_list_all/introspection.py
+++ b/aws_list_all/introspection.py
@@ -8,7 +8,10 @@ VERBS_LISTINGS = ['Describe', 'Get', 'List']
 
 SERVICE_BLACKLIST = [
     'cur',  # costs and usage reports
+    'devicefarm',  # requires manual whitelisting
     'discovery',  # requires manual whitelisting
+    'fms',  # service needs opt-in
+    'kinesis-video-archived-media',  # service needs opt in
     'support',  # support has no payable resources
 ]
 
@@ -20,6 +23,11 @@ DEPRECATED_OR_DISALLOWED = {
         'GetRoom',
         'GetSkillGroup',
         'ListSkills',
+    ],
+    'config': [
+        'DescribeAggregationAuthorizations',
+        'DescribeConfigurationAggregators',
+        'DescribePendingAggregationRequests',
     ],
     # service need opt-in
     'cloudhsm': [
@@ -62,6 +70,7 @@ AWS_RESOURCE_QUERIES = {
         'DescribeAdjustmentTypes', 'DescribeTerminationPolicyTypes', 'DescribeAutoScalingNotificationTypes',
         'DescribeScalingProcessTypes', 'DescribeMetricCollectionTypes', 'DescribeLifecycleHookTypes'
     ],
+    'clouddirectory': ['ListManagedSchemaArns'],
     'cloudhsm': ['ListAvailableZones'],
     'cloudtrail': ['ListPublicKeys'],
     'codebuild': ['ListCuratedEnvironmentImages'],
@@ -69,6 +78,7 @@ AWS_RESOURCE_QUERIES = {
     'codepipeline': ['ListActionTypes'],
     'devicefarm': ['ListDevices', 'ListOfferings', 'ListOfferingTransactions'],
     'directconnect': ['DescribeLocations'],
+    'dynamodb': ['DescribeEndpoints'],
     'dms': ['DescribeEndpointTypes', 'DescribeOrderableReplicationInstances'],
     'ec2': [
         'DescribePrefixLists', 'DescribeAvailabilityZones', 'DescribeVpcEndpointServices', 'DescribeSpotPriceHistory',
@@ -80,19 +90,26 @@ AWS_RESOURCE_QUERIES = {
     'elastictranscoder': ['ListPresets'],
     'elb': ['DescribeLoadBalancerPolicyTypes', 'DescribeLoadBalancerPolicies'],
     'elbv2': ['DescribeSSLPolicies'],
+    'es': ['DescribeReservedElasticsearchInstanceOfferings', 'GetCompatibleElasticsearchVersions'],
     'inspector': ['ListRulesPackages'],
     'lex-models': ['GetBuiltinIntents', 'GetBuiltinSlotTypes'],
     'lightsail': ['GetBlueprints', 'GetBundles', 'GetRegions'],
     'mediaconvert': ['DescribeEndpoints'],
+    'medialive': ['ListOfferings'],
+    'neptune': ['DescribeDBEngineVersions', 'DescribeEventCategories'],
     'pricing': ['DescribeServices'],
     'polly': ['DescribeVoices'],
     'rds': ['DescribeDBEngineVersions', 'DescribeSourceRegions', 'DescribeCertificates', 'DescribeEventCategories'],
     'redshift': [
-        'DescribeClusterVersions', 'DescribeReservedNodeOfferings', 'DescribeOrderableClusterOptions',
-        'DescribeEventCategories'
+        'DescribeClusterVersions',
+        'DescribeReservedNodeOfferings',
+        'DescribeOrderableClusterOptions',
+        'DescribeEventCategories',
+        'DescribeClusterTracks',
     ],
     'route53': ['GetCheckerIpRanges', 'ListGeoLocations'],
     'ssm': ['DescribeAvailablePatches', 'GetInventorySchema'],
+    'xray': ['GetSamplingRules'],
 }
 
 NOT_RESOURCE_DESCRIPTIONS = {
@@ -169,9 +186,10 @@ PARAMETERS_REQUIRED = {
     'gamelift': ['DescribeGameSessionDetails', 'DescribeGameSessions', 'DescribePlayerSessions'],
     'glue': ['GetDataflowGraph'],
     'health': ['DescribeEventTypes', 'DescribeEntityAggregates', 'DescribeEvents'],
-    'iot': ['GetLoggingOptions', 'GetEffectivePolicies'],
-    'kinesis': ['ListShards'],
+    'iot': ['GetLoggingOptions', 'GetEffectivePolicies', 'ListAuditFindings'],
+    'kinesis': ['DescribeStreamConsumer', 'ListShards'],
     'kinesisvideo': ['DescribeStream', 'ListTagsForStream'],
+    'mediastore': ['DescribeContainer'],
     'opsworks': [
         'DescribeAgentVersions', 'DescribeApps', 'DescribeCommands', 'DescribeDeployments', 'DescribeEcsClusters',
         'DescribeElasticIps', 'DescribeElasticLoadBalancers', 'DescribeInstances', 'DescribeLayers',
@@ -180,6 +198,7 @@ PARAMETERS_REQUIRED = {
     'pricing': ['GetProducts'],
     'redshift': ['DescribeTableRestoreStatus', 'DescribeClusterSecurityGroups'],
     'route53domains': ['GetContactReachabilityStatus'],
+    'secretsmanager': ['GetRandomPassword'],
     'shield': ['DescribeSubscription', 'ListProtections'],
     'ssm': ['DescribeAssociation', 'ListComplianceItems'],
     'waf-regional': ['ListActivatedRulesInRuleGroup'],

--- a/aws_list_all/introspection.py
+++ b/aws_list_all/introspection.py
@@ -13,10 +13,38 @@ SERVICE_BLACKLIST = [
 ]
 
 DEPRECATED_OR_DISALLOWED = {
+    # service need opt-in
+    'alexaforbusiness': [
+        'GetDevice',
+        'GetProfile',
+        'GetRoom',
+        'GetSkillGroup',
+        'ListSkills',
+    ],
+    # service need opt-in
+    'cloudhsm': [
+        'ListHapgs',
+        'ListHsms',
+        'ListLunaClients',
+    ],
     'directconnect': ['DescribeInterconnects'],  # needs opt-in
+    'dms': [
+        # migration service needs to be created
+        'DescribeReplicationTaskAssessmentResults'
+    ],
     'ec2': ['DescribeScheduledInstances', 'DescribeReservedInstancesListings'],  # needs opt-in
     'emr': ['DescribeJobFlows'],  # deprecated
+    'greengrass': ['GetServiceRoleForAccount'],  # Role needs to be created
     'iam': ['GetCredentialReport'],  # credential report needs to be created
+    'iot': ['DescribeDefaultAuthorizer'],  # authorizer needs to be created
+    'mediaconvert': ['ListJobTemplates', 'ListJobs', 'ListPresets',
+                     'ListQueues'],  # service needs customer-specific endpoint
+    'mturk': [
+        'GetAccountBalance', 'ListBonusPayments', 'ListHITs', 'ListQualificationRequests', 'ListReviewableHITs',
+        'ListWorkerBlocks'
+    ],  # service needs opt-in
+    'servicecatalog': ['ListTagOptions'],  # requires a Tag Option Migration
+    'workdocs': ['DescribeUsers'],  # need to be AWS-root
 }
 
 DISALLOWED_FOR_IAM_USERS = {
@@ -45,7 +73,7 @@ AWS_RESOURCE_QUERIES = {
     'ec2': [
         'DescribePrefixLists', 'DescribeAvailabilityZones', 'DescribeVpcEndpointServices', 'DescribeSpotPriceHistory',
         'DescribeHostReservationOfferings', 'DescribeRegions', 'DescribeReservedInstancesOfferings', 'DescribeIdFormat',
-        'DescribeVpcClassicLinkDnsSupport'
+        'DescribeVpcClassicLinkDnsSupport', 'DescribeAggregateIdFormat'
     ],
     'elasticache': ['DescribeCacheParameterGroups', 'DescribeCacheEngineVersions'],
     'elasticbeanstalk': ['ListAvailableSolutionStacks', 'PlatformSummaryList'],
@@ -53,8 +81,10 @@ AWS_RESOURCE_QUERIES = {
     'elb': ['DescribeLoadBalancerPolicyTypes', 'DescribeLoadBalancerPolicies'],
     'elbv2': ['DescribeSSLPolicies'],
     'inspector': ['ListRulesPackages'],
-    'lex-models': ['GetBuiltinIntents'],
+    'lex-models': ['GetBuiltinIntents', 'GetBuiltinSlotTypes'],
     'lightsail': ['GetBlueprints', 'GetBundles', 'GetRegions'],
+    'mediaconvert': ['DescribeEndpoints'],
+    'pricing': ['DescribeServices'],
     'polly': ['DescribeVoices'],
     'rds': ['DescribeDBEngineVersions', 'DescribeSourceRegions', 'DescribeCertificates', 'DescribeEventCategories'],
     'redshift': [
@@ -73,32 +103,42 @@ NOT_RESOURCE_DESCRIPTIONS = {
     'codebuild': ['ListBuilds'],
     'config': [
         'GetComplianceSummaryByResourceType', 'GetComplianceSummaryByConfigRule', 'DescribeComplianceByConfigRule',
-        'DescribeComplianceByResource', 'DescribeConfigRuleEvaluationStatus'
+        'DescribeComplianceByResource', 'DescribeConfigRuleEvaluationStatus', 'GetDiscoveredResourceCounts'
     ],
+    'dax': ['DescribeDefaultParameters', 'DescribeParameterGroups'],
     'devicefarm': ['GetAccountSettings', 'GetOfferingStatus'],
-    'dms': ['DescribeAccountAttributes'],
+    'dms': ['DescribeAccountAttributes', 'DescribeEventCategories'],
     'ds': ['GetDirectoryLimits'],
     'dynamodb': ['DescribeLimits'],
     'ec2': [
-        'DescribeAccountAttributes', 'DescribeDhcpOptions', 'DescribeVpcClassicLink', 'DescribeVpcClassicLinkDnsSupport'
+        'DescribeAccountAttributes', 'DescribeDhcpOptions', 'DescribeVpcClassicLink',
+        'DescribeVpcClassicLinkDnsSupport', 'DescribePrincipalIdFormat'
     ],
     'ecr': ['GetAuthorizationToken'],
     'elasticache': ['DescribeReservedCacheNodesOfferings'],
-    'elasticbeanstalk': ['DescribeEvents'],
+    'elasticbeanstalk': ['DescribeAccountAttributes', 'DescribeEvents'],
     'elb': ['DescribeAccountLimits'],
     'elbv2': ['DescribeAccountLimits'],
     'es': ['ListElasticsearchVersions'],
-    'gamelift': ['DescribeEC2InstanceLimits'],
+    'events': ['DescribeEventBus'],
+    'gamelift': ['DescribeEC2InstanceLimits', 'DescribeMatchmakingConfigurations', 'DescribeMatchmakingRuleSets'],
+    'glue': ['GetCatalogImportStatus'],
+    'guardduty': ['GetInvitationsCount'],
     'iam': ['GetAccountPasswordPolicy', 'GetAccountSummary', 'GetUser', 'GetAccountAuthorizationDetails'],
     'inspector': ['DescribeCrossAccountAccessRole'],
-    'iot': ['GetRegistrationCode', 'DescribeEndpoint'],
+    'iot': [
+        'GetRegistrationCode', 'DescribeEndpoint', 'DescribeEventConfigurations', 'GetIndexingConfiguration',
+        'GetV2LoggingOptions', 'ListV2LoggingLevels'
+    ],
     'kinesis': ['DescribeLimits'],
     'lambda': ['GetAccountSettings'],
-    'opsworks': ['DescribeMyUserProfile', 'DescribeUserProfiles'],
+    'opsworks': ['DescribeMyUserProfile', 'DescribeUserProfiles', 'DescribeOperatingSystems'],
     'opsworkscm': ['DescribeAccountAttributes'],
     'rds': ['DescribeAccountAttributes', 'DescribeDBEngineVersions', 'DescribeReservedDBInstancesOfferings'],
+    'resourcegroupstaggingapi': ['GetResources', 'GetTagKeys'],
     'route53': ['GetTrafficPolicyInstanceCount', 'GetHostedZoneCount', 'GetHealthCheckCount', 'GetGeoLocation'],
-    'ses': ['GetSendQuota'],
+    'ses': ['GetSendQuota', 'GetAccountSendingEnabled'],
+    'shield': ['GetSubscriptionState'],
     'sms': ['GetServers'],
     'snowball': ['GetSnowballUsage'],
     'sns': ['GetSMSAttributes', 'ListPhoneNumbersOptedOut'],
@@ -109,12 +149,14 @@ NOT_RESOURCE_DESCRIPTIONS = {
 }
 
 PARAMETERS_REQUIRED = {
+    'batch': ['ListJobs'],
     'cloudformation': ['GetTemplateSummary', 'DescribeStackResources', 'DescribeStackEvents', 'GetTemplate'],
     'cloudhsm': ['DescribeHsm', 'DescribeLunaClient'],
     'cloudtrail': ['GetEventSelectors'],
     'codecommit': ['GetBranch'],
     'cognito-idp': ['GetUser'],
-    'ec2': ['DescribeSpotDatafeedSubscription'],
+    'directconnect': ['DescribeDirectConnectGatewayAssociations', 'DescribeDirectConnectGatewayAttachments'],
+    'ec2': ['DescribeSpotDatafeedSubscription', 'DescribeLaunchTemplateVersions'],
     'ecs': ['ListContainerInstances', 'ListServices', 'ListTasks'],
     'efs': ['DescribeMountTargets'],
     'elasticache': ['ListAllowedNodeTypeModifications', 'DescribeCacheSecurityGroups'],
@@ -125,17 +167,23 @@ PARAMETERS_REQUIRED = {
     ],
     'elbv2': ['DescribeRules', 'DescribeListeners'],
     'gamelift': ['DescribeGameSessionDetails', 'DescribeGameSessions', 'DescribePlayerSessions'],
+    'glue': ['GetDataflowGraph'],
     'health': ['DescribeEventTypes', 'DescribeEntityAggregates', 'DescribeEvents'],
-    'iot': ['GetLoggingOptions'],
+    'iot': ['GetLoggingOptions', 'GetEffectivePolicies'],
+    'kinesis': ['ListShards'],
+    'kinesisvideo': ['DescribeStream', 'ListTagsForStream'],
     'opsworks': [
         'DescribeAgentVersions', 'DescribeApps', 'DescribeCommands', 'DescribeDeployments', 'DescribeEcsClusters',
         'DescribeElasticIps', 'DescribeElasticLoadBalancers', 'DescribeInstances', 'DescribeLayers',
         'DescribePermissions', 'DescribeRaidArrays', 'DescribeVolumes'
     ],
+    'pricing': ['GetProducts'],
     'redshift': ['DescribeTableRestoreStatus', 'DescribeClusterSecurityGroups'],
     'route53domains': ['GetContactReachabilityStatus'],
     'shield': ['DescribeSubscription', 'ListProtections'],
-    'ssm': ['DescribeAssociation'],
+    'ssm': ['DescribeAssociation', 'ListComplianceItems'],
+    'waf-regional': ['ListActivatedRulesInRuleGroup'],
+    'workdocs': ['DescribeActivities'],  # need to be root
 }
 
 
@@ -151,10 +199,10 @@ def get_verbs(service):
     return set(re.sub("([A-Z])", "_\\1", x).split("_")[1] for x in client.meta.method_to_api_mapping.values())
 
 
-def get_listing_operations(service):
+def get_listing_operations(service, region=None, selected_operations=()):
     """Return a list of API calls which (probably) list resources created by the user
     in the given service (in contrast to AWS-managed or default resources)"""
-    client = get_client(service)
+    client = get_client(service, region)
     operations = []
     for operation in client.meta.service_model.operation_names:
         if not any(operation.startswith(prefix) for prefix in VERBS_LISTINGS):
@@ -169,6 +217,8 @@ def get_listing_operations(service):
         if operation in NOT_RESOURCE_DESCRIPTIONS.get(service, []):
             continue
         if operation in DEPRECATED_OR_DISALLOWED.get(service, []):
+            continue
+        if selected_operations and operation not in selected_operations:
             continue
         operations.append(operation)
     return operations

--- a/aws_list_all/query.py
+++ b/aws_list_all/query.py
@@ -40,8 +40,17 @@ RESULT_IGNORE_ERRORS = {
     },
     'iot': {
         # full iot service not available in all advertised regions
+        'DescribeAccountAuditConfiguration': ['An error occurred', 'No listing'],
+        'ListActiveViolations': 'An error occurred',
+        'ListIndices': 'An error occurred',
+        'ListJobs': 'An error occurred',
         'ListOTAUpdates': 'An error occurred',
+        'ListScheduledAudits': 'An error occurred',
+        'ListSecurityProfiles': 'An error occurred',
         'ListStreams': 'An error occurred',
+    },
+    'iotanalytics': {
+        'DescribeLoggingOptions': 'An error occurred',
     },
     'lightsail': {
         # lightsail GetDomains only available in us-east-1
@@ -51,10 +60,20 @@ RESULT_IGNORE_ERRORS = {
         # rekognition stream processors not available in all advertised regions
         'ListStreamProcessors': 'AccessDeniedException',
     },
+    'shield': {
+        'DescribeDRTAccess': 'An error occurred',
+        'DescribeEmergencyContactSettings': 'An error occurred',
+    },
+    'snowball': {
+        'ListCompatibleImages': 'An error occurred',
+    },
     'storagegateway': {
         # The storagegateway advertised but not available in some regions
         'DescribeTapeArchives': 'InvalidGatewayRequestException',
         'ListTapes': 'InvalidGatewayRequestException',
+    },
+    'xray': {
+        'GetEncryptionConfig': 'No listing',
     },
 }
 
@@ -94,10 +113,13 @@ def acquire_listing(what):
     except Exception as exc:  # pylint:disable=broad-except
         result_type = RESULT_ERROR
 
-        ignored_str_err = RESULT_IGNORE_ERRORS.get(service, {}).get(operation)
-        if ignored_str_err is not None:
-            if ignored_str_err in str(exc):
-                result_type = RESULT_NOTHING
+        ignored_err = RESULT_IGNORE_ERRORS.get(service, {}).get(operation)
+        if ignored_err is not None:
+            if not isinstance(ignored_err, list):
+                ignored_err = list(ignored_err)
+            for ignored_str_err in ignored_err:
+                if ignored_str_err in str(exc):
+                    result_type = RESULT_NOTHING
 
         if "is not supported in this region" in str(exc):
             result_type = RESULT_NOTHING


### PR DESCRIPTION
- `get_regions_for_service()` now takes a tuple of desired regions and returns
  confluence of desired regions and regions the service is available.
- `get_client()` defaults to SDK config for region choice.
- Additional filtering-out of aws-managed resources and API strangeness.
  - KMS keys (E.G. lightsail's keys are showing up in the `ListKeys` operation).
  - Tweaked filter-choice for AWS-managed SSM patches.
  - Remove Internet Gateways attached to DefaultVPCs.
  - MediaLive `ListChannels` and `ListInputs` (sometimes) returns an empty list of Channels, but
    indicates it was truncated.
  - List MultiRegion CloudTrail trails only in their `HomeRegion`.
  - Remove AWS-provided/default CloudWatch Metrics.
  - And more...
- Additional support for many new services.
- Additional support for many ignorable exceptions.