### PR TITLE
Use us-east-1 to query route53

### DIFF
--- a/aws_list_all/client.py
+++ b/aws_list_all/client.py
@@ -8,6 +8,8 @@ def get_regions_for_service(service, regions=()):
     restricted by a possible set of regions."""
     if service == "s3":
         return ['us-east-1']  # s3 ListBuckets is a global request, so no region required.
+    if service == "route53":
+        return ['us-east-1']  # route53 is a global service, but the endpoint is in us-east-1.
     service_regions = boto3.Session().get_available_regions(service)
     if regions:
         # If regions were passed, return the intersecion.


### PR DESCRIPTION
Route53 is a global service so doesn't belong to a region, but the API endpoint is in us-east-1.

This makes various listings now work, but not record sets.

Updates #4.