### PR TITLE
Added -q --sequential option for running the program single-threaded.

### DIFF
--- a/aws_list_all/__main__.py
+++ b/aws_list_all/__main__.py
@@ -47,12 +47,7 @@ def main():
         action='append',
         help='Restrict querying to the given operation (can be specified multiple times)'
     )
-    query.add_argument(
-        '-q',
-        '--sequential',
-        action='store_true',
-        help='Run queries sequentially without threading'
-    )
+    query.add_argument('-q', '--sequential', action='store_true', help='Run queries sequentially without threading')
     query.add_argument('-d', '--directory', default='.', help='Directory to save result listings to')
     query.add_argument('-v', '--verbose', action='count', help='Print detailed info during run')
 

--- a/aws_list_all/__main__.py
+++ b/aws_list_all/__main__.py
@@ -47,6 +47,12 @@ def main():
         action='append',
         help='Restrict querying to the given operation (can be specified multiple times)'
     )
+    query.add_argument(
+        '-q',
+        '--sequential',
+        action='store_true',
+        help='Run queries sequentially without threading'
+    )
     query.add_argument('-d', '--directory', default='.', help='Directory to save result listings to')
     query.add_argument('-v', '--verbose', action='count', help='Print detailed info during run')
 
@@ -112,7 +118,7 @@ def main():
                 pass
             os.chdir(args.directory)
         services = args.service or get_services()
-        do_query(services, args.region, args.operation, verbose=args.verbose or 0)
+        do_query(services, args.region, args.operation, verbose=args.verbose or 0, sequential=args.sequential)
     elif args.command == 'show':
         if args.listingfile:
             do_list_files(args.listingfile, verbose=args.verbose or 0)

--- a/aws_list_all/introspection.py
+++ b/aws_list_all/introspection.py
@@ -340,7 +340,10 @@ def get_service_regions():
 def get_regions_for_service(requested_service, requested_regions=()):
     """Given a service name, return a list of region names where this service can have resources,
     restricted by a possible set of regions."""
-    regions = set(get_service_regions()[requested_service])
+    allregions = get_service_regions()
+    if requested_service not in allregions:
+        return list()
+    regions = set(allregions[requested_service])
     return list(regions) if not requested_regions else list(sorted(set(regions) & set(requested_regions)))
 
 

--- a/aws_list_all/introspection.py
+++ b/aws_list_all/introspection.py
@@ -23,6 +23,7 @@ SERVICE_BLACKLIST = [
     'cloudsearchdomain',  # Domain-specific endpoint required
     'mediastore-data',  # Mediastore Container-specific endpoint required
     's3control',  # TODO: Account-ID specific endpoint required
+    'managedblockchain',  # TODO: Unclear, does not have a region
 ]
 
 DEPRECATED_OR_DISALLOWED = {

--- a/aws_list_all/query.py
+++ b/aws_list_all/query.py
@@ -186,7 +186,7 @@ NOT_AVAILABLE_FOR_ACCOUNT_STRINGS = [
 NOT_AVAILABLE_STRINGS = NOT_AVAILABLE_FOR_REGION_STRINGS + NOT_AVAILABLE_FOR_ACCOUNT_STRINGS
 
 
-def do_query(services, selected_regions=(), selected_operations=(), verbose=0):
+def do_query(services, selected_regions=(), selected_operations=(), verbose=0, sequential=False):
     """For the given services, execute all selected operations (default: all) in selected regions
     (default: all)"""
     to_run = []
@@ -201,7 +201,11 @@ def do_query(services, selected_regions=(), selected_operations=(), verbose=0):
     shuffle(to_run)  # Distribute requests across endpoints
     results_by_type = defaultdict(list)
     print('...done. Executing queries...')
-    for result in ThreadPool(32).imap_unordered(partial(acquire_listing, verbose), to_run):
+    if sequential:
+        results = map(partial(acquire_listing, verbose), to_run)
+    else:
+        results = ThreadPool(32).imap_unordered(partial(acquire_listing, verbose), to_run)
+    for result in results:
         results_by_type[result[0]].append(result)
         if verbose > 1:
             print('ExecutedQueryResult: {}'.format(result))


### PR DESCRIPTION
This is a nice tool but wasn't working for me, so I made it work for me.  The option to run single-threaded is very useful where memory usage is a concern and running time isn't.  Additionally, this addresses issue #7 by cutting out the call to multiprocessing methods when the option is specified.

The managedblockchain commit was necessary for the tool to run on my machine, so it is included here as well.