### PR TITLE
prevent KeyError when requested_service is unknown

### DIFF
--- a/aws_list_all/introspection.py
+++ b/aws_list_all/introspection.py
@@ -340,7 +340,7 @@ def get_service_regions():
 def get_regions_for_service(requested_service, requested_regions=()):
     """Given a service name, return a list of region names where this service can have resources,
     restricted by a possible set of regions."""
-    regions = set(get_service_regions()[requested_service])
+    regions = set(get_service_regions().get(requested_service, []))
     return list(regions) if not requested_regions else list(sorted(set(regions) & set(requested_regions)))
 
 


### PR DESCRIPTION
Fixes #15

This prevents an exception when a requested service is unknown to the region.