### PR TITLE
Specify the value type for the argument 'query --parallel' as int.

### DIFF
--- a/aws_list_all/__main__.py
+++ b/aws_list_all/__main__.py
@@ -47,7 +47,7 @@ def main():
         action='append',
         help='Restrict querying to the given operation (can be specified multiple times)'
     )
-    query.add_argument('-p', '--parallel', default=32, help='Number of request to do in parallel')
+    query.add_argument('-p', '--parallel', default=32, type=int, help='Number of request to do in parallel')
     query.add_argument('-d', '--directory', default='.', help='Directory to save result listings to')
     query.add_argument('-v', '--verbose', action='count', help='Print detailed info during run')
 


### PR DESCRIPTION
I like your tool and wanted to run it using `--parallel` option, but found it threw an exception if I set any value; ``TypeError: unsupported operand type(s) for -: 'str' and 'int'`` for Python 2 and `TypeError: '<' not supported between instances of 'str' and 'int'` for 3. I set the `argparse` default type to fix.