### PR TITLE
Add Docker usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+COPY . /app
+RUN python setup.py install
+
+ENTRYPOINT ["aws_list_all"]
+CMD ["--help"]

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,14 @@ region, and operation used to find them. They can be dumped with::
   aws-list-all show data/ec2_*
   aws-list-all show --verbose data/ec2_DescribeSecurityGroups_eu-west-1.json
 
+Docker
+-----
+.. code-block:: bash
+    git clone https://github.com/JohannesEbke/aws_list_all
+    cd aws_list_all/
+    docker build -t aws_list_all:latest .
+    docker run --rm -v $HOME/.aws:/root/.aws -t aws_list_all:latest --profile myprofile
+
 How do I really list everything?
 ------------------------------------------------
 


### PR DESCRIPTION
```
λ docker run --rm -t aws_list_all:latest
usage: aws_list_all [-h] COMMAND ...

List AWS resources on one account across regions and services. Saves result into
json files, which can then be passed to this tool again to list the contents.

optional arguments:
  -h, --help       show this help message and exit

subcommands:
  List of subcommands. Use <subcommand> --help for more parameters

  COMMAND
    query          Query AWS for resources
    show           Display saved listings
    introspect     Print introspection debugging information
    recreate-caches
                   Recreate service and region caches
```